### PR TITLE
feat: agency id validation notices

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -57,9 +57,7 @@ public class AgencyConsistencyValidator extends FileValidator {
       // agency_id is recommended even when there is only 1 agency
       if (!agency.hasAgencyId()) {
         noticeContainer.addValidationNotice(
-                new AgencyIdRecommendedForSingleAgency(
-                        agency.csvRowNumber(),
-                        agency.agencyName()));
+            new AgencyIdRecommendedForSingleAgency(agency.csvRowNumber(), agency.agencyName()));
       }
       // no further validation required
       return;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -53,6 +53,15 @@ public class AgencyConsistencyValidator extends FileValidator {
   public void validate(NoticeContainer noticeContainer) {
     final int agencyCount = agencyTable.entityCount();
     if (agencyCount < 2) {
+      GtfsAgency agency = agencyTable.getEntities().get(0);
+      // agency_id is recommended even when there is only 1 agency
+      if (!agency.hasAgencyId()) {
+        noticeContainer.addValidationNotice(
+                new AgencyIdRecommendedForSingleAgency(
+                        agency.csvRowNumber(),
+                        agency.agencyName()));
+      }
+      // no further validation required
       return;
     }
 
@@ -117,6 +126,21 @@ public class AgencyConsistencyValidator extends FileValidator {
     }
   }
 
+  /**
+   * {@code agency.agencyId } recommended, even for single agency record.
+   *
+   * <p>Severity: {@code SeverityLevel.WARNING}
+   */
+  static class AgencyIdRecommendedForSingleAgency extends ValidationNotice {
+    private final long csvRowNumber;
+    private final String agencyName;
+
+    AgencyIdRecommendedForSingleAgency(long csvRowNumber, String agencyName) {
+      super(SeverityLevel.WARNING);
+      this.csvRowNumber = csvRowNumber;
+      this.agencyName = agencyName;
+    }
+  }
   /**
    * Inconsistent timezone among agencies.
    *

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidator.java
@@ -50,7 +50,7 @@ public class RouteAgencyIdValidator extends FileValidator {
     int totalAgencies = agencyTable.entityCount();
 
     for (GtfsRoute route : routeTable.getEntities()) {
-      if (!route.hasAgencyId())  {
+      if (!route.hasAgencyId()) {
         if (totalAgencies > 1) {
           // add error notice if more than one agency
           noticeContainer.addValidationNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidator.java
@@ -29,6 +29,7 @@ import org.mobilitydata.gtfsvalidator.table.*;
  * agency in the feed.
  *
  * <p>Generated notice: {@link MissingRequiredFieldNotice}.
+ *
  * <p>Generated notice: {@link AgencyIdRecommendedNotice}.
  */
 @GtfsValidator
@@ -47,25 +48,24 @@ public class RouteAgencyIdValidator extends FileValidator {
 
     // routes.agency_id is required when there are multiple agencies
     // or an agencyId is specified for single agency
-    boolean agencyIdRequired = (agencyTable.entityCount() > 1) || agencyTable.getEntities().get(0).hasAgencyId();
+    boolean agencyIdRequired =
+        (agencyTable.entityCount() > 1) || agencyTable.getEntities().get(0).hasAgencyId();
 
     for (GtfsRoute route : routeTable.getEntities()) {
       if (!route.hasAgencyId()) {
         if (agencyIdRequired) {
           noticeContainer.addValidationNotice(
-                  new MissingRequiredFieldNotice(
-                          routeTable.gtfsFilename(),
-                          route.csvRowNumber(),
-                          GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
+              new MissingRequiredFieldNotice(
+                  routeTable.gtfsFilename(),
+                  route.csvRowNumber(),
+                  GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
         } else {
-          noticeContainer.addValidationNotice(
-                  new AgencyIdRecommendedNotice(
-                          route.csvRowNumber()));
+          noticeContainer.addValidationNotice(new AgencyIdRecommendedNotice(route.csvRowNumber()));
         }
       }
     }
-      // No need to check reference integrity because it is done by a validator generated from
-      // @ForeignKey annotation.
+    // No need to check reference integrity because it is done by a validator generated from
+    // @ForeignKey annotation.
   }
   /**
    * AgencyId field is recommended even if only one agency.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidator.java
@@ -47,19 +47,19 @@ public class RouteAgencyIdValidator extends FileValidator {
   public void validate(NoticeContainer noticeContainer) {
 
     // routes.agency_id is required when there are multiple agencies
-    // or an agencyId is specified for single agency
-    boolean agencyIdRequired =
-        (agencyTable.entityCount() > 1) || agencyTable.getEntities().get(0).hasAgencyId();
+    int totalAgencies = agencyTable.entityCount();
 
     for (GtfsRoute route : routeTable.getEntities()) {
-      if (!route.hasAgencyId()) {
-        if (agencyIdRequired) {
+      if (!route.hasAgencyId())  {
+        if (totalAgencies > 1) {
+          // add error notice if more than one agency
           noticeContainer.addValidationNotice(
               new MissingRequiredFieldNotice(
                   routeTable.gtfsFilename(),
                   route.csvRowNumber(),
                   GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
         } else {
+          // add warning notice if only one agency
           noticeContainer.addValidationNotice(new AgencyIdRecommendedNotice(route.csvRowNumber()));
         }
       }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
@@ -44,20 +44,21 @@ public class TripAgencyIdValidator extends FileValidator {
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-    if (agencyTable.entityCount() < 2) {
-      // routes.agency_id is not required when there is a single agency.
-      return;
-    }
-    for (GtfsRoute route : routeTable.getEntities()) {
-      if (!route.hasAgencyId()) {
-        noticeContainer.addValidationNotice(
-            new MissingRequiredFieldNotice(
-                routeTable.gtfsFilename(),
-                route.csvRowNumber(),
-                GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
+  // routes.agency_id is required when there is are multiple agencvies
+    if (agencyTable.entityCount() > 1) {
+      for (GtfsRoute route : routeTable.getEntities()) {
+        if (!route.hasAgencyId()) {
+          noticeContainer.addValidationNotice(
+                  new MissingRequiredFieldNotice(
+                          routeTable.gtfsFilename(),
+                          route.csvRowNumber(),
+                          GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
+        }
       }
+    }
+    else {
+    }
       // No need to check reference integrity because it is done by a validator generated from
       // @ForeignKey annotation.
-    }
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
@@ -44,7 +44,7 @@ public class TripAgencyIdValidator extends FileValidator {
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-  // routes.agency_id is required when there is are multiple agencvies
+  // routes.agency_id is required when there is are multiple agencies
     if (agencyTable.entityCount() > 1) {
       for (GtfsRoute route : routeTable.getEntities()) {
         if (!route.hasAgencyId()) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -63,6 +63,20 @@ public class AgencyConsistencyValidatorTest {
   }
 
   @Test
+  public void singleAgencyPresentButNoAgencyIdSetShouldGenerateWarningNotice() {
+    List<ValidationNotice> notices = generateNotices(ImmutableList.of(
+            createAgency(
+                    0,
+                    null,
+                    "agency name",
+                    "www.mobilitydata.org",
+                    ZoneId.of("America/Montreal"),
+                    Locale.CANADA)));
+    assertThat(notices).containsExactly(new AgencyConsistencyValidator.AgencyIdRecommendedForSingleAgency( 0, "agency name"));
+    assertThat(notices.get(0).getSeverityLevel()).isEqualTo(SeverityLevel.WARNING);
+  }
+
+  @Test
   public void multipleAgenciesPresentButNoAgencyIdSetShouldGenerateErrorNotice() {
     List<ValidationNotice> notices = generateNotices(ImmutableList.of(
                     createAgency(

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
@@ -62,10 +63,8 @@ public class AgencyConsistencyValidatorTest {
   }
 
   @Test
-  public void multipleAgenciesPresentButNoAgencyIdSetShouldGenerateNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(
+  public void multipleAgenciesPresentButNoAgencyIdSetShouldGenerateErrorNotice() {
+    List<ValidationNotice> notices = generateNotices(ImmutableList.of(
                     createAgency(
                         0,
                         "first agency",
@@ -79,8 +78,9 @@ public class AgencyConsistencyValidatorTest {
                         "agency name",
                         "www.mobilitydata.org",
                         ZoneId.of("America/Montreal"),
-                        Locale.CANADA))))
-        .containsExactly(new MissingRequiredFieldNotice("agency.txt", 1, "agency_id"));
+                        Locale.CANADA)));
+    assertThat(notices).containsExactly(new MissingRequiredFieldNotice("agency.txt", 1, "agency_id"));
+    assertThat(notices.get(0).getSeverityLevel()).isEqualTo(SeverityLevel.ERROR);
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -64,36 +64,43 @@ public class AgencyConsistencyValidatorTest {
 
   @Test
   public void singleAgencyPresentButNoAgencyIdSetShouldGenerateWarningNotice() {
-    List<ValidationNotice> notices = generateNotices(ImmutableList.of(
-            createAgency(
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(
+                createAgency(
                     0,
                     null,
                     "agency name",
                     "www.mobilitydata.org",
                     ZoneId.of("America/Montreal"),
                     Locale.CANADA)));
-    assertThat(notices).containsExactly(new AgencyConsistencyValidator.AgencyIdRecommendedForSingleAgency( 0, "agency name"));
+    assertThat(notices)
+        .containsExactly(
+            new AgencyConsistencyValidator.AgencyIdRecommendedForSingleAgency(0, "agency name"));
     assertThat(notices.get(0).getSeverityLevel()).isEqualTo(SeverityLevel.WARNING);
   }
 
   @Test
   public void multipleAgenciesPresentButNoAgencyIdSetShouldGenerateErrorNotice() {
-    List<ValidationNotice> notices = generateNotices(ImmutableList.of(
-                    createAgency(
-                        0,
-                        "first agency",
-                        "agency name",
-                        "www.mobilitydata.org",
-                        ZoneId.of("America/Montreal"),
-                        Locale.CANADA),
-                    createAgency(
-                        1,
-                        null,
-                        "agency name",
-                        "www.mobilitydata.org",
-                        ZoneId.of("America/Montreal"),
-                        Locale.CANADA)));
-    assertThat(notices).containsExactly(new MissingRequiredFieldNotice("agency.txt", 1, "agency_id"));
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(
+                createAgency(
+                    0,
+                    "first agency",
+                    "agency name",
+                    "www.mobilitydata.org",
+                    ZoneId.of("America/Montreal"),
+                    Locale.CANADA),
+                createAgency(
+                    1,
+                    null,
+                    "agency name",
+                    "www.mobilitydata.org",
+                    ZoneId.of("America/Montreal"),
+                    Locale.CANADA)));
+    assertThat(notices)
+        .containsExactly(new MissingRequiredFieldNotice("agency.txt", 1, "agency_id"));
     assertThat(notices.get(0).getSeverityLevel()).isEqualTo(SeverityLevel.ERROR);
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
@@ -79,6 +79,6 @@ public class RouteAgencyIdValidatorTest {
             ImmutableList.of(createRoute(0, "route_0", null, "Route 0")), noticeContainer);
     new RouteAgencyIdValidator(agencyTable, routeTable).validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-            .containsExactly(new RouteAgencyIdValidator.AgencyIdRecommendedNotice(0));
+        .containsExactly(new RouteAgencyIdValidator.AgencyIdRecommendedNotice(0));
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
@@ -68,7 +68,7 @@ public class RouteAgencyIdValidatorTest {
   }
 
   @Test
-  public void agencyIdErrorWhenOnlyOneAgencyWithAgencyId() {
+  public void agencyIdWarningWhenOnlyOneAgencyWithAgencyId() {
 
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsAgencyTableContainer agencyTable =
@@ -79,8 +79,6 @@ public class RouteAgencyIdValidatorTest {
             ImmutableList.of(createRoute(0, "route_0", null, "Route 0")), noticeContainer);
     new RouteAgencyIdValidator(agencyTable, routeTable).validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(
-            new MissingRequiredFieldNotice(
-                routeTable.gtfsFilename(), 0, GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
+            .containsExactly(new RouteAgencyIdValidator.AgencyIdRecommendedNotice(0));
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
@@ -1,0 +1,85 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.*;
+
+public class RouteAgencyIdValidatorTest {
+
+    public static GtfsRoute createRoute(long rowNumber, String routeId, String agencyId, String shortName){
+
+        return new GtfsRoute.Builder()
+                .setCsvRowNumber(rowNumber)
+                .setAgencyId(agencyId)
+                .setRouteId(routeId)
+                .setRouteShortName(shortName)
+                .build();
+    }
+    public static GtfsAgency createAgency(
+            long csvRowNumber,
+            String agencyId,
+            String agencyName ) {
+        return new GtfsAgency.Builder()
+                .setCsvRowNumber(csvRowNumber)
+                .setAgencyId(agencyId)
+                .setAgencyName(agencyName)
+                .build();
+    }
+    @Test
+    public void agencyIdRequiredWhenMoreThanOneAgency() {
+
+        NoticeContainer noticeContainer = new NoticeContainer();
+        GtfsAgencyTableContainer agencyTable = GtfsAgencyTableContainer.forEntities(ImmutableList.of(
+                createAgency(0, "oneAgencyId", "Agency with Id"),
+                createAgency(1, null, "Agency with no ID")
+        ), noticeContainer);
+        GtfsRouteTableContainer routeTable = GtfsRouteTableContainer.forEntities(ImmutableList.of(
+                createRoute(0, "route_0", "agency0", "Route 0"),
+                createRoute(1, "route_1", null, "Route 1")),
+        noticeContainer);
+        new RouteAgencyIdValidator(agencyTable,routeTable).validate(noticeContainer);
+        assertThat(noticeContainer.getValidationNotices()).containsExactly(new MissingRequiredFieldNotice(
+                routeTable.gtfsFilename(),
+                1,
+                GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME
+        ));
+    }
+
+    @Test
+    public void agencyIdWarningWhenOnlyOneAgencyWithNoAgencyId() {
+
+        NoticeContainer noticeContainer = new NoticeContainer();
+        GtfsAgencyTableContainer agencyTable = GtfsAgencyTableContainer.forEntities(ImmutableList.of(
+                createAgency(1, null, "Agency with no ID")
+        ), noticeContainer);
+        GtfsRouteTableContainer routeTable = GtfsRouteTableContainer.forEntities(ImmutableList.of(
+                        createRoute(0, "route_0", null, "Route 0")),
+                noticeContainer);
+        new RouteAgencyIdValidator(agencyTable,routeTable).validate(noticeContainer);
+        assertThat(noticeContainer.getValidationNotices()).containsExactly(new RouteAgencyIdValidator.AgencyIdRecommendedNotice(
+                0
+        ));
+    }
+
+    @Test
+    public void agencyIdErrorWhenOnlyOneAgencyWithAgencyId() {
+
+        NoticeContainer noticeContainer = new NoticeContainer();
+        GtfsAgencyTableContainer agencyTable = GtfsAgencyTableContainer.forEntities(ImmutableList.of(
+                createAgency(1, "agencyId", "Agency with ID")
+        ), noticeContainer);
+        GtfsRouteTableContainer routeTable = GtfsRouteTableContainer.forEntities(ImmutableList.of(
+                        createRoute(0, "route_0", null, "Route 0")),
+                noticeContainer);
+        new RouteAgencyIdValidator(agencyTable,routeTable).validate(noticeContainer);
+        assertThat(noticeContainer.getValidationNotices()).containsExactly(new MissingRequiredFieldNotice(
+                routeTable.gtfsFilename(),
+                0,
+                GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME
+        ));
+    }
+
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteAgencyIdValidatorTest.java
@@ -1,6 +1,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
@@ -9,77 +10,77 @@ import org.mobilitydata.gtfsvalidator.table.*;
 
 public class RouteAgencyIdValidatorTest {
 
-    public static GtfsRoute createRoute(long rowNumber, String routeId, String agencyId, String shortName){
+  public static GtfsRoute createRoute(
+      long rowNumber, String routeId, String agencyId, String shortName) {
 
-        return new GtfsRoute.Builder()
-                .setCsvRowNumber(rowNumber)
-                .setAgencyId(agencyId)
-                .setRouteId(routeId)
-                .setRouteShortName(shortName)
-                .build();
-    }
-    public static GtfsAgency createAgency(
-            long csvRowNumber,
-            String agencyId,
-            String agencyName ) {
-        return new GtfsAgency.Builder()
-                .setCsvRowNumber(csvRowNumber)
-                .setAgencyId(agencyId)
-                .setAgencyName(agencyName)
-                .build();
-    }
-    @Test
-    public void agencyIdRequiredWhenMoreThanOneAgency() {
+    return new GtfsRoute.Builder()
+        .setCsvRowNumber(rowNumber)
+        .setAgencyId(agencyId)
+        .setRouteId(routeId)
+        .setRouteShortName(shortName)
+        .build();
+  }
 
-        NoticeContainer noticeContainer = new NoticeContainer();
-        GtfsAgencyTableContainer agencyTable = GtfsAgencyTableContainer.forEntities(ImmutableList.of(
+  public static GtfsAgency createAgency(long csvRowNumber, String agencyId, String agencyName) {
+    return new GtfsAgency.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setAgencyId(agencyId)
+        .setAgencyName(agencyName)
+        .build();
+  }
+
+  @Test
+  public void agencyIdRequiredWhenMoreThanOneAgency() {
+
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsAgencyTableContainer agencyTable =
+        GtfsAgencyTableContainer.forEntities(
+            ImmutableList.of(
                 createAgency(0, "oneAgencyId", "Agency with Id"),
-                createAgency(1, null, "Agency with no ID")
-        ), noticeContainer);
-        GtfsRouteTableContainer routeTable = GtfsRouteTableContainer.forEntities(ImmutableList.of(
+                createAgency(1, null, "Agency with no ID")),
+            noticeContainer);
+    GtfsRouteTableContainer routeTable =
+        GtfsRouteTableContainer.forEntities(
+            ImmutableList.of(
                 createRoute(0, "route_0", "agency0", "Route 0"),
                 createRoute(1, "route_1", null, "Route 1")),
-        noticeContainer);
-        new RouteAgencyIdValidator(agencyTable,routeTable).validate(noticeContainer);
-        assertThat(noticeContainer.getValidationNotices()).containsExactly(new MissingRequiredFieldNotice(
-                routeTable.gtfsFilename(),
-                1,
-                GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME
-        ));
-    }
+            noticeContainer);
+    new RouteAgencyIdValidator(agencyTable, routeTable).validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new MissingRequiredFieldNotice(
+                routeTable.gtfsFilename(), 1, GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
+  }
 
-    @Test
-    public void agencyIdWarningWhenOnlyOneAgencyWithNoAgencyId() {
+  @Test
+  public void agencyIdWarningWhenOnlyOneAgencyWithNoAgencyId() {
 
-        NoticeContainer noticeContainer = new NoticeContainer();
-        GtfsAgencyTableContainer agencyTable = GtfsAgencyTableContainer.forEntities(ImmutableList.of(
-                createAgency(1, null, "Agency with no ID")
-        ), noticeContainer);
-        GtfsRouteTableContainer routeTable = GtfsRouteTableContainer.forEntities(ImmutableList.of(
-                        createRoute(0, "route_0", null, "Route 0")),
-                noticeContainer);
-        new RouteAgencyIdValidator(agencyTable,routeTable).validate(noticeContainer);
-        assertThat(noticeContainer.getValidationNotices()).containsExactly(new RouteAgencyIdValidator.AgencyIdRecommendedNotice(
-                0
-        ));
-    }
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsAgencyTableContainer agencyTable =
+        GtfsAgencyTableContainer.forEntities(
+            ImmutableList.of(createAgency(1, null, "Agency with no ID")), noticeContainer);
+    GtfsRouteTableContainer routeTable =
+        GtfsRouteTableContainer.forEntities(
+            ImmutableList.of(createRoute(0, "route_0", null, "Route 0")), noticeContainer);
+    new RouteAgencyIdValidator(agencyTable, routeTable).validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new RouteAgencyIdValidator.AgencyIdRecommendedNotice(0));
+  }
 
-    @Test
-    public void agencyIdErrorWhenOnlyOneAgencyWithAgencyId() {
+  @Test
+  public void agencyIdErrorWhenOnlyOneAgencyWithAgencyId() {
 
-        NoticeContainer noticeContainer = new NoticeContainer();
-        GtfsAgencyTableContainer agencyTable = GtfsAgencyTableContainer.forEntities(ImmutableList.of(
-                createAgency(1, "agencyId", "Agency with ID")
-        ), noticeContainer);
-        GtfsRouteTableContainer routeTable = GtfsRouteTableContainer.forEntities(ImmutableList.of(
-                        createRoute(0, "route_0", null, "Route 0")),
-                noticeContainer);
-        new RouteAgencyIdValidator(agencyTable,routeTable).validate(noticeContainer);
-        assertThat(noticeContainer.getValidationNotices()).containsExactly(new MissingRequiredFieldNotice(
-                routeTable.gtfsFilename(),
-                0,
-                GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME
-        ));
-    }
-
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsAgencyTableContainer agencyTable =
+        GtfsAgencyTableContainer.forEntities(
+            ImmutableList.of(createAgency(1, "agencyId", "Agency with ID")), noticeContainer);
+    GtfsRouteTableContainer routeTable =
+        GtfsRouteTableContainer.forEntities(
+            ImmutableList.of(createRoute(0, "route_0", null, "Route 0")), noticeContainer);
+    new RouteAgencyIdValidator(agencyTable, routeTable).validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new MissingRequiredFieldNotice(
+                routeTable.gtfsFilename(), 0, GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
+  }
 }


### PR DESCRIPTION
**Summary:**

Addresses #878

1. Added test for existing validation requiring `agency_id` if more than one agency in `agency.txt`
1. generate a **warning** if there is a single agency in `agency.txt` but `agency_id` is not provided
1. generate a **warning** if `agency_id` is missing in `routes.txt` and a single agency is defined in `agency.txt` with no `agency_id`
1. generate an **error** if `agency_id` is missing in `routes.txt` but is included for single agency in `agency.txt`

**Expected behavior:** 

N/A


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) (N/A)
